### PR TITLE
Add site author as default page author

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="post">
   <div class="post-info">
-    <span>Written by&nbsp;</span>
+    <span>Written by</span>
     {% if page.author %}
         {{ page.author }}
     {% else %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,12 @@ layout: default
 
 <div class="post">
   <div class="post-info">
-    <span>Written by&nbsp;</span>{{ page.author }}
+    <span>Written by&nbsp;</span>
+    {% if page.author %}
+        {{ page.author }}
+    {% else %}
+        {{ site.author.name }}
+    {% endif %}
 
     {% if page.date %}
       <br>


### PR DESCRIPTION
I just wanted to say I love how simple and clean this theme is!

One of the ways I thought it may be improved is to set the site author's name as the default author on posts. This way users don't have to manually type out their name for every blog post. Feel free to merge or suggest changes!