### PR TITLE
Strip HTML first before trunctating

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,7 @@ layout: default
         <div class="catalogue-line"></div>
 
         <p>
-          {{ post.content | truncatewords: 30 | strip_html }}
+          {{ post.content | strip_html | truncatewords: 30 }}
         </p>
 
       </div>


### PR DESCRIPTION
Strip HTML first so that long HTML blocks (like script tags) get removed correctly