### PR TITLE
Make RSS feed discoverable. Fix #34.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ sass:
 
 # Gems
 plugins:
+  - jekyll-feed
   - jekyll-paginate
   # - jemoji #Uncomment this to allow emoji in your post
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,4 +18,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/favicon-32x32.png" | relative_url }}">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ "/assets/favicon-16x16.png" | relative_url }}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ "/assets/apple-touch-icon.png" | relative_url }}">
+
+  <!-- RSS -->
+  {% feed_meta %}
 </head>


### PR DESCRIPTION
Adds `feed_meta` to header to make the RSS feed discoverable by feed readers. The XML file (the feed itself) was properly being created already when the feed plugin is enabled.