### PR TITLE
Add Meta Description to Head Template

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% if page.title == "Home" %}
+    <meta name="description" content="{{ site.description }}">
+  {% endif %}
 
   <title>
     {% if page.title == "Home" %}


### PR DESCRIPTION
Now, the meta description tag will contain the text specified within the `_config.yml` file.
Also, the tag will only be displayed on the landing page.