### PR TITLE
Updated .catalogue-item class

### DIFF
--- a/_sass/tale/_catalogue.scss
+++ b/_sass/tale/_catalogue.scss
@@ -4,6 +4,7 @@
     color: $default-color;
     display: inline-block;
     padding: 2rem 0;
+    outline: none;
 
     &:hover .catalogue-line,
     &:focus .catalogue-line {


### PR DESCRIPTION
outline: none; property is included into post anchor tag class(.catalogue-item), So whenever user clicks on the post no outline will be shown on the post. Good for user experience.