### PR TITLE
allow customisation of homepage excerpt

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,11 @@ layout: default
         <div class="catalogue-line"></div>
 
         <p>
-          {{ post.content | strip_html | truncatewords: 30 }}
+          {% if post.excerpt_separator %}
+            {{ post.excerpt | strip_html }}
+          {% else %}
+            {{ post.content | strip_html | truncatewords: 30 }}
+          {% endif %}
         </p>
 
       </div>

--- a/_posts/2017-03-16-example-content.md
+++ b/_posts/2017-03-16-example-content.md
@@ -3,9 +3,10 @@ layout: post
 title: "Example Content"
 author: "Chester"
 tags: Example
+excerpt_separator: <!--more-->
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt ornare nibh, non elementum augue tempus eget. Pellentesque tempus scelerisque iaculis. Nullam interdum ultricies nibh quis sollicitudin. Donec ornare fermentum facilisis. Ut at sem ac sem imperdiet varius a eget tortor. Nam eu augue eget orci semper maximus in eget augue. Mauris ornare, nisl ut suscipit consectetur, mi quam interdum tellus, at rutrum quam eros ultrices mi.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tincidunt ornare nibh, non elementum augue tempus eget. Pellentesque tempus scelerisque iaculis.<!--more--> Nullam interdum ultricies nibh quis sollicitudin. Donec ornare fermentum facilisis. Ut at sem ac sem imperdiet varius a eget tortor. Nam eu augue eget orci semper maximus in eget augue. Mauris ornare, nisl ut suscipit consectetur, mi quam interdum tellus, at rutrum quam eros ultrices mi.
 
 # Headers
 {% highlight markdown %}

--- a/_posts/2017-03-29-introducing-tale.md
+++ b/_posts/2017-03-29-introducing-tale.md
@@ -4,9 +4,10 @@ title:  "Introducing Tale"
 author: "Chester"
 comments: true
 tags: Tale
+excerpt_separator: <!--more-->
 ---
 
-Tale is a minimal [Jekyll](https://jekyllrb.com/) theme curated for storytellers. It is designed and developed by [myself](https://github.com/chesterhow/) for a friend who writes short stories.
+Tale is a minimal [Jekyll](https://jekyllrb.com/) theme curated for storytellers. It is designed and developed by [myself](https://github.com/chesterhow/) for a friend who writes short stories.<!--more-->
 
 ## Tale features
 - Compatible with GitHub Pages

--- a/_posts/2021-04-30-managing-excerpt.md
+++ b/_posts/2021-04-30-managing-excerpt.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: "Managing Excerpt"
+author: "Chester"
+tags: Tutorial
+excerpt_separator: <!--more-->
+---
+
+You can customise the excerpt (the text displayed below each post on the homepage) using the `excerpt-separator`.<!--more--> Here's how you can do so!
+
+### Steps
+
+1. Add `excerpt_separator: <!--more-->` to the frontmatter of your blog post.
+
+2. Insert this `<!--more-->` at where you would like the excerpt to cut off in your blog post.
+
+### Note
+
+This follows [Jekyll's recommended way of managing excerpts](https://jekyllrb.com/docs/posts/#post-excerpts).

--- a/tale.gemspec
+++ b/tale.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "tale"
-  spec.version       = "0.2.1"
+  spec.version       = "0.2.2"
   spec.authors       = ["Chester How"]
   spec.email         = ["chesterhow@gmail.com"]
 


### PR DESCRIPTION
### Changes
Fixed bug where some languages do not get properly truncated by adding a way to manage homepage excerpt
- Following Jekyll's recommended method of doing so (https://jekyllrb.com/docs/posts/#post-excerpts).

Fixes #95, and addresses the subtitle request in #91